### PR TITLE
Chagned the outcome word by expense

### DIFF
--- a/src/server/constants.js
+++ b/src/server/constants.js
@@ -11,7 +11,7 @@ module.exports = {
   ],
   CATEGOTY_TYPES: [
     'income',
-    'outcome'
+    'expense'
   ],
   RESPONSE: {
     STATUSES: {

--- a/src/server/models/category.spec.js
+++ b/src/server/models/category.spec.js
@@ -71,7 +71,7 @@ describe('Category module', function () {
             name: 'A name',
             description: 'This is a test description',
             creation: 'Just string',
-            type: 'outcome'
+            type: 'expense'
           };
 
           this.getCategoryInstance(categoryInvalidCreationDataType);


### PR DESCRIPTION
# Description

Changed the `outcome` wording by `expense`, so the app now follows the ubiquitous language.

This is very important since the language of the app should be clear about the business and not ambiguous, having two terms referring to the same thing.